### PR TITLE
129170 / cf / Corregir cambio de estatus de usuario después del registro

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -142,6 +142,8 @@ module.exports = function(UserIdentity) {
                         loopback.getModelByType(loopback.User);
         var userObj = (options.profileToUser || profileToUser)(provider, profile, options);
         userObj.realm = invitedUser.realm || 'AUTHOR';
+        userObj.status = 'ACTIVE';
+        
         if (!userObj.email && !options.emailOptional) {
           process.nextTick(function() {
             return cb(g.f('email is missing from the user profile'));


### PR DESCRIPTION
## Tareas
- [#129170 Corregir cambio de estatus de usuario después del registro](http://manoderecha.net/md/index.php/task/129170)

## Test
Usuario nuevo registrado, status = ACTIVE:
<img width="203" alt="screen shot 2017-04-05 at 8 49 49 am" src="https://cloud.githubusercontent.com/assets/152053/24708970/193d8c00-19de-11e7-9720-6eaf28e5dc2c.png">
